### PR TITLE
feat:AI 퀴즈 생성 요청 수 유효성 검증 추가 (최대 3개)

### DIFF
--- a/src/main/java/com/cmdlee/quizsushi/ai/controller/AiController.java
+++ b/src/main/java/com/cmdlee/quizsushi/ai/controller/AiController.java
@@ -8,6 +8,7 @@ import com.cmdlee.quizsushi.global.util.RejectBot;
 import com.cmdlee.quizsushi.quiz.dto.request.GenerateQuizRequest;
 import com.cmdlee.quizsushi.quiz.dto.response.GenerateQuizResponse;
 import com.cmdlee.quizsushi.ai.service.AiService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,7 +29,7 @@ public class AiController {
 
     @PostMapping("/quizzes/questions")
     public ResponseEntity<CommonApiResponse<List<GenerateQuizResponse>>> generateQuizzes(
-            @RequestBody GenerateQuizRequest request,
+            @Valid @RequestBody GenerateQuizRequest request,
             @AuthenticationPrincipal CustomMemberDetails memberDetails) {
         getAuthenticatedMemberId(memberDetails);
         List<GenerateQuizResponse> generateQuizByAI = aiService.generateQuizByAI(request);

--- a/src/main/java/com/cmdlee/quizsushi/quiz/dto/request/GenerateQuizRequest.java
+++ b/src/main/java/com/cmdlee/quizsushi/quiz/dto/request/GenerateQuizRequest.java
@@ -1,15 +1,19 @@
 package com.cmdlee.quizsushi.quiz.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @Builder
 @AllArgsConstructor
 public class GenerateQuizRequest {
     private String topic;
     private String description;
+    @Min(value = 1, message = "최소 1개의 문제를 생성해야 합니다.")
+    @Max(value = 3, message = "최대 3개의 문제만 생성할 수 있습니다.")
     private int count;
     private String difficulty;
     private String questionType;


### PR DESCRIPTION
## PR 설명

 클라이언트가 과도하게 많은 문제 수를 요청할 경우 다음과 같은 문제가 발생합니다:
- 처리 시간 급증 (최대 10분 이상)
- 클라이언트 UX 저하 및 무한 대기
- 로컬 AI 서버 리소스 고갈

이를 방지하기 위해, 생성 가능한 문제 수를 최소 1개, 최대 3개로 제한하는 유효성 검증을 DTO 단에서 도입했습니다.
해당 제약은 클라이언트에서도 명시되어 있으며, 서버와 클라이언트 간 일관성을 확보하는 목적도 포함됩니다.

---

## 변경 요약

- [x] 기능 추가
- [ ] 버그 수정
- [x] 테스트 보완 또는 개선
- [ ] 리팩토링
- [ ] 기타 (설명):

---

## 체크리스트

- [x] 테스트 코드를 작성하거나 기존 테스트를 수정했습니다.
- [x] 모든 테스트가 통과됩니다.
- [x] 변경사항이 기존 동작에 영향을 주지 않는지 확인했습니다.
- [x] PR 설명에 변경 이유가 충분히 명시되어 있습니다.
