### PR TITLE
fix: 닉네임 필드명 오타 수정 (nickName → nickname)으로 API 연동 오류 해결

### DIFF
--- a/src/main/java/com/cmdlee/quizsushi/member/domain/model/QuizsushiMember.java
+++ b/src/main/java/com/cmdlee/quizsushi/member/domain/model/QuizsushiMember.java
@@ -70,7 +70,7 @@ public class QuizsushiMember extends TimeBaseEntity {
     }
 
     public void updateProfile(UpdateProfileRequest request) {
-        this.nickname = request.getNickName();
+        this.nickname = request.getNickname();
         this.birthDate = request.getLocalDateBirth();
         this.gender = request.getGender();
     }

--- a/src/main/java/com/cmdlee/quizsushi/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/cmdlee/quizsushi/member/dto/request/UpdateProfileRequest.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 @Getter
 @AllArgsConstructor
 public class UpdateProfileRequest {
-    private String nickName;
+    private String nickname;
     private String birth;
     private String gender;
 


### PR DESCRIPTION
## PR 설명

회원 정보 수정 시 닉네임 필드가 서버에 null로 전달되는 문제를 해결하였습니다.
클라이언트에서는 nickname으로 전송하지만, 서버 DTO에서 nickName으로 정의되어 매핑이 실패로 인한 문제였습니다.
DTO 필드명을 nickname으로 일치시켜 문제를 해결하였습니다.

---

## 변경 요약

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 테스트 보완 또는 개선
- [ ] 리팩토링
- [ ] 기타 (설명):

---
